### PR TITLE
Add scss linter and readme

### DIFF
--- a/css/.scss-lint.yml
+++ b/css/.scss-lint.yml
@@ -1,0 +1,194 @@
+scss_files: "**/*.scss"
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BorderZero:
+    enabled: true
+    convention: zero
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: true
+    style: long
+
+  HexNotation:
+    enabled: true
+    style: lowercase
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: false
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space
+    width: 2
+
+  LeadingZero:
+    enabled: true
+    style: include_zero
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase
+
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+
+  PlaceholderInExtend:
+    enabled: false
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  PropertyUnits:
+    enabled: true
+    global: [ 'rem', 'px' ]
+    properties: {}
+
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase
+
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+
+  StringQuotes:
+    enabled: true
+    style: double_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingZero:
+    enabled: true
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: false
+    properties: []
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: false
+
+  Compass::*:
+    enabled: false

--- a/css/README.md
+++ b/css/README.md
@@ -1,0 +1,51 @@
+## SCSS Styleguide Linter
+
+These SCSS rules are the result of effort to standardize code during Spree Themes development; it's the fruit of discussions initiated by:
+
+- Carlos Mumo
+- Fernando Perales
+- Herman Moreno
+- Edmundo Perez
+- Emmanuel Delgado
+
+Currently Copied from: [Spree Themes: Scss Lint](https://github.com/magma-labs/spree-themes-source-code-/blob/master/.scss-lint.yml)
+
+It's not intended to be the Holy Grail but the very basis towards high quality styling.
+
+### Configuration
+
+[Scss-lint](https://github.com/brigade/scss-lint) to
+do an automated syntax analysis of your SCSSS; please refer to the [documentation](https://github.com/brigade/scss-lint#editor-integration) for editor integration.
+
+Basically, you'll need to copy the `.scss-lint.yml` to your project's root folder.
+
+### Some Tips
+
+#### Fonts
+
+It's a good practice to use `10px` attached to the `html` element in
+order to express all the required font size changes on `rem` and make
+those calcutations easy to perform.
+
+
+```
+html {
+  font-size: 10px;
+}
+```
+
+With this, if the design guideline requires a 64px font, the CSS will
+look like this:
+
+```
+p {
+  font-size 6.4rem;
+}
+```
+
+### TODO:
+
+- Update with more tips
+- Add references to styleguides
+- Add linter for plain css
+- Create a Wiki (?)


### PR DESCRIPTION
### Solves

> There is a need to standardize CSS throughout Magmalabs with the intention to delivering high quality products

### Changes

- Add SCSS basic linter based on Spree Themes
